### PR TITLE
fix extra tstore and tload if bytes.len - 28 % 32 == 0, clear only initial slot when agus'ing transient bytes

### DIFF
--- a/src/TransientBytesLib.sol
+++ b/src/TransientBytesLib.sol
@@ -52,8 +52,11 @@ library TransientBytesLib {
                 for {} 1 {} {
                     tstore(slot, calldataload(offset))
                     offset := add(offset, 0x20)
-                    if gt(offset, endOffset) { break }
-                    slot := add(slot, 1)
+                    if lt(offset, endOffset) {
+                        slot := add(slot, 1)
+                        continue
+                    }
+                    break
                 }
             }
         }
@@ -85,8 +88,11 @@ library TransientBytesLib {
                 for {} 1 {} {
                     tstore(slot, mload(offset))
                     offset := add(offset, 0x20)
-                    if gt(offset, endOffset) { break }
-                    slot := add(slot, 1)
+                    if lt(offset, endOffset) {
+                        slot := add(slot, 1)
+                        continue
+                    }
+                    break
                 }
             }
         }
@@ -115,8 +121,11 @@ library TransientBytesLib {
                 for {} 1 {} {
                     mstore(offset, tload(slot))
                     offset := add(offset, 0x20)
-                    if gt(offset, endOffset) { break }
-                    slot := add(slot, 1)
+                    if lt(offset, endOffset) {
+                        slot := add(slot, 1)
+                        continue
+                    }
+                    break
                 }
                 mstore(endOffset, 0)
             }
@@ -124,25 +133,9 @@ library TransientBytesLib {
     }
 
     function agus(TransientBytes storage self) internal {
-        uint256 len = self.length();
         /// @solidity memory-safe-assembly
         assembly {
             tstore(self.slot, 0)
-
-            if gt(len, sub(0x20, LENGTH_BYTES)) {
-                // Derive extended slots.
-                mstore(0x00, self.slot)
-                let slot := keccak256(0x00, 0x20)
-
-                // Store remainder.
-                let offset := sub(0x20, LENGTH_BYTES)
-                for {} 1 {} {
-                    tstore(slot, 0)
-                    offset := add(offset, 0x20)
-                    if gt(offset, len) { break }
-                    slot := add(slot, 1)
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
- In the current implementation, if the bytes length - 28 is a multiple of 32, there will be an extra tstore to the next derived slot (in the case of `set` and `setCd` and an extra tload (in the case of `get`) because the loop continues if the offset == endOffset. This pr suggests a fix to it

- Also, this pr, makes `agus` to just clear the initial slot and ignore derived slots, this should be save since get uses the length to know if to calculate and load derived slots.