### PR TITLE
🔗 feat(multicall): Add support for individual reverts with flag

### DIFF
--- a/test/PayableMulticallable.t.sol
+++ b/test/PayableMulticallable.t.sol
@@ -17,7 +17,7 @@ contract PayableMulticallableTest is Test {
         data[0] = abi.encodeCall(multicall.deposit, (amount));
         data[1] = abi.encodeCall(multicall.deposit, (amount));
         vm.expectRevert(stdError.arithmeticError);
-        multicall.multicall{value: amount}(data);
+        multicall.multicall{value: amount}(true, data);
     }
 
     function test_allowsNormalMulticall() public {
@@ -27,7 +27,7 @@ contract PayableMulticallableTest is Test {
         data[0] = abi.encodeCall(multicall.deposit, (2 ether));
         data[1] = abi.encodeCall(multicall.deposit, (2.9 ether));
         data[2] = abi.encodeCall(multicall.returnRemainder, ());
-        multicall.multicall{value: 5 ether}(data);
+        multicall.multicall{value: 5 ether}(true, data);
 
         assertEq(multicall.balanceOf(user), 4.9 ether);
         assertEq(user.balance, 0.1 ether);
@@ -40,7 +40,7 @@ contract PayableMulticallableTest is Test {
         data[0] = abi.encodeCall(multicall.deposit, (2 ether));
         data[1] = abi.encodeCall(multicall.deposit, (2.9 ether));
         data[2] = abi.encodeCall(multicall.returnRemainder, ());
-        multicall.multicall{value: 5 ether}(data);
+        multicall.multicall{value: 5 ether}(true, data);
 
         assertEq(multicall.balanceOf(user), 4.9 ether);
         assertEq(user.balance, 0.1 ether);

--- a/test/PayableMulticallable.t.sol
+++ b/test/PayableMulticallable.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {Test} from "forge-std/Test.sol";
+import {console,Test} from "forge-std/Test.sol";
 import {stdError} from "forge-std/StdError.sol";
 import {Multicallable} from "./mocks/Multicallable.sol";
 
@@ -40,9 +40,12 @@ contract PayableMulticallableTest is Test {
         data[0] = abi.encodeCall(multicall.deposit, (1 ether));
         data[1] = abi.encodeCall(multicall.deposit, (2.1 ether));
         data[2] = abi.encodeCall(multicall.deposit, (1 ether));
-        multicall.multicall{value: 3 ether}(false, data);
+        bytes[] memory responses = multicall.multicall{value: 3 ether}(false, data);
 
         assertEq(multicall.balanceOf(user), 2 ether);
+        assertEq(abi.decode(responses[0], (uint256)), 1 ether);
+        assertEq(responses[1], abi.encodeWithSignature("Panic(uint256)", (0x11)));
+        assertEq(abi.decode(responses[2], (uint256)), 2 ether);
     }
 
     function test_returnResetsValue() public {

--- a/test/PayableMulticallable.t.sol
+++ b/test/PayableMulticallable.t.sol
@@ -33,6 +33,18 @@ contract PayableMulticallableTest is Test {
         assertEq(user.balance, 0.1 ether);
     }
 
+    function test_allowsIndividualRevert() public {
+        address user = makeAddr("user");
+        hoax(user, 3 ether);
+        bytes[] memory data = new bytes[](3);
+        data[0] = abi.encodeCall(multicall.deposit, (1 ether));
+        data[1] = abi.encodeCall(multicall.deposit, (2.1 ether));
+        data[2] = abi.encodeCall(multicall.deposit, (1 ether));
+        multicall.multicall{value: 3 ether}(false, data);
+
+        assertEq(multicall.balanceOf(user), 2 ether);
+    }
+
     function test_returnResetsValue() public {
         address user = makeAddr("user");
         hoax(user, 5 ether);

--- a/test/PayableMulticallable.t.sol
+++ b/test/PayableMulticallable.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {console,Test} from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 import {stdError} from "forge-std/StdError.sol";
 import {Multicallable} from "./mocks/Multicallable.sol";
 

--- a/test/mocks/Multicallable.sol
+++ b/test/mocks/Multicallable.sol
@@ -7,8 +7,9 @@ import {PayableMulticallable} from "../../src/PayableMulticallable.sol";
 contract Multicallable is PayableMulticallable {
     mapping(address => uint256) public balanceOf;
 
-    function deposit(uint256 amount) external payable standalonePayable {
+    function deposit(uint256 amount) external payable standalonePayable returns (uint256) {
         balanceOf[msg.sender] += useValue(amount);
+        return balanceOf[msg.sender];
     }
 
     function withdraw(uint256 amount) external payable {


### PR DESCRIPTION
@Philogy 

Similar functionality to `tryAggregate` from [Multicall3](https://github.com/mds1/multicall/blob/main/src/Multicall3.sol#L60) and other multicall contracts. Can also move this to a new function if preferred.